### PR TITLE
Improve BLE Stability, Add Retry Logic, Introduce Ruff/Black Linting, and Restructure Integration Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,23 @@ The Govee Dreamview T1 Home Assistant Custom Integration allows you to integrate
 
 ## Installation
 
+This integration requires [Bluetooth](https://www.home-assistant.io/integrations/bluetooth/) integration to be installed and enabled. You must have at least one Bluetooth adapter configured that is capable of establishing an active connection.
+
 ### HACS (recommended)
 
-This integration is available in HACS (Home Assistant Community Store).
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=NecroKote&repository=hass-govee-h6199)
 
-1. Install HACS if you don't have it already
+### HACS
+
+1. [Install HACS](https://www.hacs.xyz/docs/use/download/download/) if you don't have it already
 2. Open HACS in Home Assistant
-3. Go to any of the sections (integrations, frontend, automation).
-4. Click on the 3 dots in the top right corner.
-5. Select "Custom repositories"
-6. Add following URL to the repository `https://github.com/necrokote/hass-govee-h6199`.
-7. Select Integration as category.
-8. Click the "ADD" button
-9. Search for "Govee Bluetooth Lights"
-10. Click the "Download" button
+3. Click on the 3 dots in the top right corner.
+4. Select "Custom repositories"
+5. Add following URL to the repository `https://github.com/necrokote/hass-govee-h6199`.
+6. Select Integration as category.
+7. Click the "ADD" button
+8. Search for "Govee Bluetooth Lights"
+9. Click the "Download" button
 
 ### Manual
 

--- a/custom_components/hass-govee-h6199/__init__.py
+++ b/custom_components/hass-govee-h6199/__init__.py
@@ -19,9 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CustomConfigEntry) -> bo
 
     ble_device = bluetooth.async_ble_device_from_address(hass, address)
     if not ble_device:
-        raise ConfigEntryNotReady(
-            f"Could not find Govee H6199 device with address {address}"
-        )
+        raise ConfigEntryNotReady(f'Could not find Govee H6199 device with address {address}')
 
     device = GoveeH6199Device(address, ble_device)
     coordinator = GoveeH6199DataCoordinator(hass, entry, device)

--- a/custom_components/hass-govee-h6199/config_flow.py
+++ b/custom_components/hass-govee-h6199/config_flow.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from bleak import BleakClient
-from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
 from govee_h6199_ble import GetFirmwareVersion, GetMacAddress, connected
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
@@ -16,6 +16,9 @@ from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_ADDRESS
 
 from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
 
 
 @dataclass
@@ -45,10 +48,13 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_devices = {}
 
     async def _get_device_info(self, device: BLEDevice) -> DeviceData:
-        async with BleakClient(device) as client:
+        client = await establish_connection(BleakClient, device, device.name or device.address)
+        try:
             async with connected(client) as govee:
                 mac = await govee.send_command(GetMacAddress())
                 firmware = await govee.send_command(GetFirmwareVersion())
+        finally:
+            await client.disconnect()
 
         return DeviceData(mac, firmware)
 
@@ -57,30 +63,26 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         name = discovery_info.name
-        self.context["title_placeholders"] = {"name": name}
+        self.context['title_placeholders'] = {'name': name}
 
         device_data = await self._get_device_info(discovery_info.device)
         self._discovered_device = Discovery(name, discovery_info, device_data)
 
-        self._log.debug("Discovered device: %s", self._discovered_device)
+        self._log.debug('Discovered device: %s', self._discovered_device)
         return await self.async_step_bluetooth_confirm()
 
-    async def async_step_bluetooth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ):
+    async def async_step_bluetooth_confirm(self, user_input: dict[str, Any] | None = None):
         """Confirm discovery."""
         if user_input is not None:
-            self._log.debug("User confirmed device: %s", user_input)
-            return self.async_create_entry(
-                title=self.context["title_placeholders"]["name"], data={}
-            )
+            self._log.debug('User confirmed device: %s', user_input)
+            return self.async_create_entry(title=self.context['title_placeholders']['name'], data={})
 
-        self._log.debug("Context: %s", self.context)
+        self._log.debug('Context: %s', self.context)
 
         self._set_confirm_only()
         return self.async_show_form(
-            step_id="bluetooth_confirm",
-            description_placeholders=self.context["title_placeholders"],
+            step_id='bluetooth_confirm',
+            description_placeholders=self.context['title_placeholders'],
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
@@ -92,7 +94,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
 
             discovery = self._discovered_devices[address]
             self._discovered_device = discovery
-            self.context["title_placeholders"] = {"name": discovery.name}
+            self.context['title_placeholders'] = {'name': discovery.name}
 
             return self.async_create_entry(title=discovery.name, data={})
 
@@ -105,17 +107,14 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
             name = discovery_info.name
             data = await self._get_device_info(discovery_info.device)
             self._discovered_devices[address] = Discovery(name, discovery_info, data)
-            self._log.debug("Discovered device: %s", self._discovered_device)
+            self._log.debug('Discovered device: %s', self._discovered_device)
 
         if not self._discovered_devices:
-            return self.async_abort(reason="no_devices_found")
+            return self.async_abort(reason='no_devices_found')
 
-        titles = {
-            address: discovery.name
-            for (address, discovery) in self._discovered_devices.items()
-        }
+        titles = {address: discovery.name for (address, discovery) in self._discovered_devices.items()}
 
         return self.async_show_form(
-            step_id="user",
+            step_id='user',
             data_schema=vol.Schema({vol.Required(CONF_ADDRESS): vol.In(titles)}),
         )

--- a/custom_components/hass-govee-h6199/const.py
+++ b/custom_components/hass-govee-h6199/const.py
@@ -1,14 +1,14 @@
 from enum import StrEnum
 
-DOMAIN = "hass-govee-h6199"
+DOMAIN = 'hass-govee-h6199'
 
 DEFAULT_SCAN_INTERVAL = 15
-UPDATE_TIMEOUT = 3
+UPDATE_TIMEOUT = 15
 
 BRIGHTNESS_SCALE = (1, 100)
 
 
 class Effect(StrEnum):
-    FILM = "film"
-    GAME = "game"
-    MUSIC = "music"
+    FILM = 'film'
+    GAME = 'game'
+    MUSIC = 'music'

--- a/custom_components/hass-govee-h6199/coordinator.py
+++ b/custom_components/hass-govee-h6199/coordinator.py
@@ -1,49 +1,100 @@
+import asyncio
 import logging
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
+from async_timeout import timeout
+from bleak.exc import BleakError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, UPDATE_TIMEOUT
 from .data import GoveeH6199Data
-from .device import GoveeH6199Device
 
-type CustomConfigEntry = ConfigEntry[GoveeH6199DataCoordinator]
+if TYPE_CHECKING:
+    from .device import GoveeH6199Device
+
+type CustomConfigEntry = ConfigEntry['GoveeH6199DataCoordinator']
+
+MAX_SOFT_FAILURES = 5
 
 
 class GoveeH6199DataCoordinator(DataUpdateCoordinator[GoveeH6199Data]):
     """Class to manage fetching Govee H6199 BLE data."""
 
-    device: GoveeH6199Device
+    device: 'GoveeH6199Device'
     config_entry: CustomConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry: CustomConfigEntry,
-        device: GoveeH6199Device,
+        device: 'GoveeH6199Device',
     ) -> None:
         self.device = device
+        self._consecutive_failures = 0
 
         super().__init__(
             hass,
-            logging.getLogger(__name__ + "@" + str(id(self))),
+            logging.getLogger(__name__ + '@' + str(id(self))),
             config_entry=entry,
             name=DOMAIN,
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
 
     async def _async_setup(self) -> None:
-        self.logger.debug("Setting up coordinator...")
-        self.hass.create_task(self.device.init(), "connect to govee device")
+        self.logger.debug('Setting up coordinator...')
+        self.hass.async_create_task(
+            self.device.init(),
+            name='connect to govee device',
+        )
 
     async def _async_update_data(self) -> GoveeH6199Data:
-        self.logger.debug("Updating data...")
+        self.logger.debug('Updating data...')
+
         try:
-            await self.device.update()
+            # Bound how long we wait for a full update; if the BLE link is
+            # too weak and we can't talk to the device within UPDATE_TIMEOUT
+            # seconds, treat it as unavailable instead of hanging indefinitely.
+            async with timeout(UPDATE_TIMEOUT):
+                await self.device.update()
+
+        except asyncio.TimeoutError as err:
+            self._consecutive_failures += 1
+            self.logger.warning(
+                'Timeout updating Govee H6199 after %s consecutive failures: %s',
+                self._consecutive_failures,
+                err,
+            )
+            raise UpdateFailed('Timeout updating Govee H6199 device') from err
+
+        except BleakError as err:
+            # Transient BLE issue - keep last known state for a while
+            self._consecutive_failures += 1
+            self.logger.warning(
+                'BLE error while updating Govee H6199 (%s/%s): %s',
+                self._consecutive_failures,
+                MAX_SOFT_FAILURES,
+                err,
+            )
+
+            if self._consecutive_failures < MAX_SOFT_FAILURES and self.device.data:
+                # Don't kill entities yet; just return stale data
+                return self.device.data
+
+            # After too many failures in a row, let HA know we are in trouble
+            raise UpdateFailed(
+                f'Unable to fetch data after ' f'{self._consecutive_failures} BLE failures: {err!r}'
+            ) from err
 
         except Exception as err:
-            raise UpdateFailed(f"Unable to fetch data: {err!r}") from err
+            # Non-BLE error - treat as hard failure immediately
+            self._consecutive_failures += 1
+            raise UpdateFailed(f'Unable to fetch data: {err!r}') from err
+
+        else:
+            # Successful update - reset failure counter
+            self._consecutive_failures = 0
 
         return self.device.data

--- a/custom_components/hass-govee-h6199/device.py
+++ b/custom_components/hass-govee-h6199/device.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
 from dataclasses import replace
-from typing import Awaitable, Callable, TypeVar, cast
+from typing import Any, Awaitable, Callable, cast
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
-from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import establish_connection
 from govee_h6199_ble import Command, GoveeH6199
 from govee_h6199_ble.commands import (
     GetBrightness,
@@ -25,9 +26,7 @@ from govee_h6199_ble.commands import (
 from .const import Effect
 from .data import GoveeH6199Data
 
-T = TypeVar("T")
-
-type SendCommandsHandle = Callable[[list[Command]], Awaitable[None]]
+SendCommandsHandle = Callable[[list[Command]], Awaitable[None]]
 
 
 class PowerOnCommandBuilder:
@@ -74,7 +73,7 @@ class PowerOnCommandBuilder:
 
 class GoveeH6199Device:
     data: GoveeH6199Data
-    ping_interval = 2
+    ping_interval = 5
 
     on_data_listeners: list[Callable[[GoveeH6199Data], None]]
 
@@ -83,14 +82,19 @@ class GoveeH6199Device:
         self.on_data_listeners = []
         self._ble_device = device
         self.address = address
-        self.logger = logging.getLogger(__name__ + "@" + str(id(self)))
+        self.logger = logging.getLogger(__name__ + '@' + str(id(self)))
         self._lock = asyncio.Lock()
 
         self._client: BleakClient | None = None
         self._govee_device: GoveeH6199 | None = None
+        # _connected_event reflects the current BLE link state.
+        # _init_event is set once after the initial init() succeeds and is not
+        # cleared on reconnects; callers typically wait on both before using
+        # the device.
         self._connected_event = asyncio.Event()
         self._init_event = asyncio.Event()
         self._ping_task: asyncio.Task | None = None
+        self._reconnect_task: asyncio.Task | None = None
 
     def add_data_listener(self, listener: Callable[[GoveeH6199Data], None]) -> None:
         self.on_data_listeners.append(listener)
@@ -104,60 +108,75 @@ class GoveeH6199Device:
             self.data = new_data
             self.notify_listeners()
 
+    def _ensure_reconnect_task(self) -> None:
+        """Ensure at most one reconnect task is running."""
+        if self._reconnect_task and not self._reconnect_task.done():
+            self.logger.debug('Reconnect task already running.')
+            return
+
+        self.logger.debug('Scheduling reconnect task...')
+        self._reconnect_task = asyncio.create_task(self._connect())
+
     async def _connect(self):
-        self.logger.debug("Starting connection task...")
-
         """Establish connection and set up Govee device."""
-        while True:
-            try:
-                self.logger.debug("Connecting to %s ...", self._ble_device.address)
-                client = await establish_connection(
-                    BleakClient,
-                    self._ble_device,
-                    self._ble_device.address,
-                    disconnected_callback=self._handle_disconnect,
-                )
-                self.logger.debug("Connected to %s", self._ble_device.address)
-                self._client = client
-                if device := GoveeH6199(client):
-                    self.logger.debug("Starting Govee device...")
-                    await device.start()
-                    self._govee_device = device
+        self.logger.debug('Starting connection task...')
+        current_task = asyncio.current_task()
 
-                self._connected_event.set()
+        try:
+            while True:
+                try:
+                    self.logger.debug('Connecting to %s ...', self._ble_device.address)
+                    client = await establish_connection(
+                        BleakClient,
+                        self._ble_device,
+                        self._ble_device.address,
+                        disconnected_callback=self._handle_disconnect,
+                    )
+                    self.logger.debug('Connected to %s', self._ble_device.address)
+                    self._client = client
+                    if device := GoveeH6199(client):
+                        self.logger.debug('Starting Govee device...')
+                        await device.start()
+                        self._govee_device = device
 
-                if existing := self._ping_task:
-                    if not existing.done():
-                        self.logger.debug("Ping task already running.")
-                        return
-                else:
-                    self.logger.debug("Starting ping task...")
-                    self._ping_task = asyncio.create_task(self._ping_loop())
+                    self._connected_event.set()
 
-                return
-            except Exception as e:
-                self.logger.warning("Connection failed: %s, retrying in 2s...", e)
-                await asyncio.sleep(2)
+                    if existing := self._ping_task:
+                        if not existing.done():
+                            self.logger.debug('Ping task already running.')
+                            return
+                    else:
+                        self.logger.debug('Starting ping task...')
+                        self._ping_task = asyncio.create_task(self._ping_loop())
+
+                    return
+                except Exception as e:
+                    self.logger.warning('Connection failed: %s, retrying in 2s...', e)
+                    await asyncio.sleep(2)
+        finally:
+            # If this _connect() is the reconnect task, clear the reference
+            if self._reconnect_task is current_task:
+                self.logger.debug('Reconnect task finished, clearing reference.')
+                self._reconnect_task = None
 
     def _handle_disconnect(self, client: BleakClient):
         """Handle disconnect from device."""
 
         if self._connected_event.is_set():
-            self.logger.debug("Disconnected from %s", client.address)
+            self.logger.debug('Disconnected from %s', client.address)
             self._connected_event.clear()
-            self._init_event.clear()
 
             # stop ping task
             if self._ping_task and not self._ping_task.done():
                 self._ping_task.cancel()
                 self._ping_task = None
 
-            # Schedule reconnection
-            asyncio.create_task(self._connect())
+            # Schedule reconnection (ensure we only have one reconnect task)
+            self._ensure_reconnect_task()
 
     async def _get_device_info(self, device: GoveeH6199):
         """Get device info using persistent connection."""
-        self.logger.debug("Getting device info...")
+        self.logger.debug('Getting device info...')
 
         await self._connected_event.wait()
 
@@ -172,40 +191,44 @@ class GoveeH6199Device:
         """Background task to ping device every 5 seconds."""
         while True:
             try:
-                self.logger.debug("Pinging device...")
+                self.logger.debug('Pinging device...')
                 power = await self._send_command(GetPowerState())
                 if self.data:
                     new_data = replace(self.data, power_state=power)
                     self.set_data_and_notify_if_changed(new_data)
 
             except Exception as e:
-                self.logger.warning("Ping failed: %s", e)
+                self.logger.warning('Ping failed: %s', e)
 
             await asyncio.sleep(self.ping_interval)
 
     async def init(self):
-        """Initialize device and start ping task."""
+        """Initialize device and start ping task (one-time bootstrap).
+
+        This is expected to be called once; on success it sets _init_event.
+        Subsequent reconnects only require _connected_event to be set.
+        """
         await self._connect()
 
         while True:
             await self._connected_event.wait()
             try:
 
-                self.logger.debug("Initializing device ...")
+                self.logger.debug('Initializing device ...')
 
                 async with self._lock:
-                    device = cast(GoveeH6199, self._govee_device)
+                    device = cast('GoveeH6199', self._govee_device)
 
                     mac = await device.send_command(GetMacAddress())
-                    self.logger.debug("Device MAC: %s", mac)
+                    self.logger.debug('Device MAC: %s', mac)
                     fw_version = await device.send_command(GetFirmwareVersion())
-                    self.logger.debug("Device Firmware Version: %s", fw_version)
+                    self.logger.debug('Device Firmware Version: %s', fw_version)
                     hw_version = await device.send_command(GetHardwareVersion())
-                    self.logger.debug("Device Hardware Version: %s", hw_version)
+                    self.logger.debug('Device Hardware Version: %s', hw_version)
 
                 power, mode, br = await self._get_device_info(device)
             except Exception as e:
-                self.logger.warning(f"Initialization failed: {e}, retrying...")
+                self.logger.warning('Initialization failed: %s, retrying...', e)
                 await asyncio.sleep(2)
                 continue
 
@@ -221,7 +244,7 @@ class GoveeH6199Device:
             )
             break
 
-        self.logger.debug("Initial data: %s", self.data)
+        self.logger.debug('Initial data: %s', self.data)
         self._init_event.set()
 
     async def update(self):
@@ -229,7 +252,10 @@ class GoveeH6199Device:
         await self._connected_event.wait()
         await self._init_event.wait()
 
-        power, mode, br = await self._get_device_info(self._govee_device)
+        if (device := self._govee_device) is None:
+            raise RuntimeError('Govee device not initialized')
+
+        power, mode, br = await self._get_device_info(device)
 
         self.data = replace(
             self.data,
@@ -237,27 +263,98 @@ class GoveeH6199Device:
             brightness=br,
             mode=mode,
         )
-        self.logger.debug("Updated data: %s", self.data)
+        self.logger.debug('Updated data: %s', self.data)
 
-    async def _send_command(self, command: Command):
-        """Send a single command to the device using persistent connection."""
+    async def _send_command(self, command: Any) -> Any:
+        """Send a single command to the device using persistent connection.
+
+        On BLE/ATT errors, force a reconnect and retry once.
+        """
+        # Fast path: make sure we're connected/initialized
         await self._connected_event.wait()
         await self._init_event.wait()
 
-        if device := self._govee_device:
-            async with self._lock:
-                self.logger.debug("Sending command: %s", command)
-                return await device.send_command(command)
+        if not self._govee_device:
+            raise RuntimeError('Govee device not initialized')
+
+        async with self._lock:
+            try:
+                self.logger.debug('Sending command: %s', command)
+                return await self._govee_device.send_command(command)
+
+            except BleakDBusError as err:
+                # ATT 0x0e (Unlikely / Failed) - usually stale/bad connection
+                self.logger.warning(
+                    'BLE DBus error while sending %s: %s. ' 'Forcing reconnect and retrying once.',
+                    command,
+                    err,
+                )
+                await self._force_reconnect()
+                return await self._retry_command_once(command)
+
+            except BleakError as err:
+                # Other Bleak-level errors
+                self.logger.warning(
+                    'Bleak error while sending %s: %s. ' 'Forcing reconnect and retrying once.',
+                    command,
+                    err,
+                )
+                await self._force_reconnect()
+                return await self._retry_command_once(command)
+
+    async def _retry_command_once(self, command: Any) -> Any:
+        """Retry a command one time after we forced a reconnect."""
+        # Wait for reconnection + (re)initialization
+        await self._connected_event.wait()
+        await self._init_event.wait()
+
+        if not self._govee_device:
+            raise RuntimeError('Govee device not initialized after reconnect')
+
+        self.logger.debug('Retrying command after reconnect: %s', command)
+        async with self._lock:
+            return await self._govee_device.send_command(command)
+
+    async def _force_reconnect(self):
+        """Try to tear down the current client and trigger reconnect logic."""
+        client = self._client
+        if client is None:
+            # Nothing to do, just ensure a connect task is running
+            self.logger.debug('No active client, ensuring connect task.')
+            self._ensure_reconnect_task()
+            return
+
+        self.logger.debug('Forcing disconnect from %s', client.address)
+
+        # Clear flags so other callers will wait
+        self._connected_event.clear()
+
+        # Stop ping loop
+        if self._ping_task and not self._ping_task.done():
+            self._ping_task.cancel()
+            self._ping_task = None
+
+        # Try to disconnect quietly
+        try:
+            await client.disconnect()
+        except Exception as err:
+            self.logger.debug('Error during forced disconnect: %s', err)
+
+        # Drop references and schedule reconnect
+        self._client = None
+        self._govee_device = None
+
+        self._ensure_reconnect_task()
 
     async def _send_commands(self, commands: list[Command]):
         """Send commands to the device using persistent connection."""
-        self.logger.debug("Sending commands: %s", commands)
+        self.logger.debug('Sending commands: %s', commands)
         for command in commands:
             await self._send_command(command)
 
     async def power_on(self, builder: PowerOnCommandBuilder):
         if new_state := builder.predict_state():
-            self.logger.debug("Powering on ...")
+            self.logger.debug('Powering on ...')
             await self._send_commands(builder.build())
             self.set_data_and_notify_if_changed(new_state)
 

--- a/custom_components/hass-govee-h6199/light.py
+++ b/custom_components/hass-govee-h6199/light.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from functools import cached_property
+from typing import ClassVar
 
 from govee_h6199_ble import MusicColorMode, VideoColorMode
 from homeassistant.components.light import (
@@ -33,9 +34,14 @@ async def async_setup_entry(
 
 class GoveeH1699(CoordinatorEntity[GoveeH6199DataCoordinator], LightEntity):
     _attr_color_mode = ColorMode.RGB
-    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_supported_color_modes: ClassVar[set[ColorMode]] = {ColorMode.RGB}
     _attr_supported_features = LightEntityFeature.EFFECT
-    _attr_effect_list = [EFFECT_OFF, Effect.MUSIC, Effect.FILM, Effect.GAME]
+    _attr_effect_list: ClassVar[list[Effect | str]] = [
+        EFFECT_OFF,
+        Effect.MUSIC,
+        Effect.FILM,
+        Effect.GAME,
+    ]
 
     def __init__(
         self,
@@ -47,14 +53,14 @@ class GoveeH1699(CoordinatorEntity[GoveeH6199DataCoordinator], LightEntity):
         self._log = logging.getLogger(__name__)
 
         btmac = self._data.address
-        device_id = btmac.replace(":", "").lower()
+        device_id = btmac.replace(':', '').lower()
 
-        self._attr_unique_id = f"{device_id}_light"
+        self._attr_unique_id = f'{device_id}_light'
         self._attr_device_info = dr.DeviceInfo(
             connections={(dr.CONNECTION_BLUETOOTH, btmac)},
-            manufacturer="Govee",
-            model_id="H1699",
-            model="Govee DreamView T1",
+            manufacturer='Govee',
+            model_id='H1699',
+            model='Govee DreamView T1',
             sw_version=self._data.fw_version,
             hw_version=self._data.hw_version,
         )
@@ -66,7 +72,7 @@ class GoveeH1699(CoordinatorEntity[GoveeH6199DataCoordinator], LightEntity):
     @cached_property
     def name(self) -> str:
         """Return the name of the light."""
-        return "Light"
+        return 'Light'
 
     @property
     def brightness(self) -> int | None:
@@ -96,9 +102,7 @@ class GoveeH1699(CoordinatorEntity[GoveeH6199DataCoordinator], LightEntity):
         on_command = PowerOnCommandBuilder(self._data)
 
         if raw_brightness := kwargs.get(ATTR_BRIGHTNESS):
-            brightness = math.ceil(
-                brightness_to_value(BRIGHTNESS_SCALE, raw_brightness)
-            )
+            brightness = math.ceil(brightness_to_value(BRIGHTNESS_SCALE, raw_brightness))
             on_command.with_brightness(brightness)
 
         if effect := kwargs.get(ATTR_EFFECT):

--- a/custom_components/hass-govee-h6199/manifest.json
+++ b/custom_components/hass-govee-h6199/manifest.json
@@ -9,6 +9,6 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/necrokote/hass-govee-h6199/issues",
     "loggers": ["custom_components.hass-govee-h6199"],
-    "requirements": ["bleak-retry-connector", "govee-h6199-ble"],
+    "requirements": ["bleak-retry-connector", "govee-h6199-ble==0.4.0"],
     "version": "0.3.0"
 }


### PR DESCRIPTION
### Summary

Tighten up reconnect handling for the `GoveeH6199Device` so we don’t end up with multiple reconnect loops or ping tasks running at once.

### What changed

- Track a single `_reconnect_task` and use `_ensure_reconnect_task()` to avoid spawning duplicate `_connect()` coroutines.
- Clear `_reconnect_task` when the reconnect task finishes, so we don’t leak tasks or lose track of state.
- Make sure the ping loop is stopped on disconnect before scheduling a reconnect.
- Document the semantics of `_connected_event` and `_init_event` (one-time bootstrap flag; not cleared on reconnects).
- Use the walrus operator when accessing `_govee_device` in `update()` for cleaner, 3.12-style code.

### Notes

The reconnect flow now relies on `_connected_event` being reset on disconnect, while `_init_event` is intentionally left set after the initial `init()` has run once. Static info (MAC/FW/HW) is treated as stable across reconnects; dynamic state is refreshed via the ping loop and updates.