### PR TITLE
Add conftest.py to alias custom_components/hass-govee-h6199 as custom…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+# pytest.ini
+[pytest]
+testpaths = tests
+filterwarnings =
+    ignore:CSR support in pyOpenSSL is deprecated:DeprecationWarning
+    ignore:X509Extension support in pyOpenSSL is deprecated:DeprecationWarning
+    ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CUSTOM_COMPONENTS_DIR = ROOT / 'custom_components'
+INTEGRATION_DIR = CUSTOM_COMPONENTS_DIR / 'hass-govee-h6199'
+
+# Ensure repo root is on sys.path
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Ensure top-level custom_components namespace exists
+cc_name = 'custom_components'
+cc = sys.modules.get(cc_name)
+if cc is None:
+    cc = types.ModuleType(cc_name)
+    cc.__path__ = [str(CUSTOM_COMPONENTS_DIR)]
+    sys.modules[cc_name] = cc
+else:
+    if not hasattr(cc, '__path__'):
+        cc.__path__ = [str(CUSTOM_COMPONENTS_DIR)]
+    elif str(CUSTOM_COMPONENTS_DIR) not in cc.__path__:
+        cc.__path__.append(str(CUSTOM_COMPONENTS_DIR))
+
+# Load the hyphenated integration as package: custom_components.hass_govee_h6199
+pkg_name = 'custom_components.hass_govee_h6199'
+if pkg_name not in sys.modules:
+    init_file = INTEGRATION_DIR / '__init__.py'
+    spec = importlib.util.spec_from_file_location(
+        pkg_name, init_file, submodule_search_locations=[str(INTEGRATION_DIR)]
+    )
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[pkg_name] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+
+# Optional legacy alias
+sys.modules.setdefault('hass_govee_h6199', sys.modules[pkg_name])

--- a/tests/test_coordinator_soft_failures.py
+++ b/tests/test_coordinator_soft_failures.py
@@ -1,0 +1,103 @@
+import asyncio
+
+import pytest
+from bleak.exc import BleakError
+from custom_components.hass_govee_h6199.coordinator import MAX_SOFT_FAILURES, GoveeH6199DataCoordinator
+from custom_components.hass_govee_h6199.data import GoveeH6199Data
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+class FakeDevice:
+    """Fake BLE device used by the coordinator in tests."""
+
+    def __init__(self):
+        self.data = GoveeH6199Data(
+            address='AA',
+            mac='AA',
+            fw_version='1.0',
+            hw_version='1',
+            power_state='on',
+            mode='static',
+            color=(255, 0, 0),
+            brightness=100,
+        )
+        self._fail_times = 0
+        self._fail_with_ble_error = False
+
+    async def init(self):
+        # no-op for tests
+        return None
+
+    async def update(self):
+        if self._fail_with_ble_error and self._fail_times > 0:
+            self._fail_times -= 1
+            raise BleakError('simulated BLE failure')
+
+
+class FakeHass:
+    """Minimal stand-in for HomeAssistant needed by the coordinator."""
+
+    def __init__(self):
+        self.tasks = []
+
+    def async_create_task(self, coro, *, name=None):
+        task = asyncio.create_task(coro, name=name)
+        self.tasks.append(task)
+        return task
+
+
+class DummyConfigEntry:
+    """Minimal stand-in for ConfigEntry for unit tests."""
+
+    def __init__(self, entry_id: str = 'test-entry') -> None:
+        self.entry_id = entry_id
+        self._unload_callbacks: list[callable] = []
+
+    def async_on_unload(self, callback):
+        """Mimic HA's ConfigEntry.async_on_unload."""
+        self._unload_callbacks.append(callback)
+        # In real HA this returns the callback; matching that is fine
+        return callback
+
+
+@pytest.mark.asyncio
+async def test_coordinator_keeps_stale_data_on_transient_ble_errors():
+    fake_device = FakeDevice()
+    hass = FakeHass()
+    entry = DummyConfigEntry()
+    coord = GoveeH6199DataCoordinator(hass, entry, fake_device)
+
+    # First, one successful update to set data & reset failures
+    data = await coord._async_update_data()
+    assert data is fake_device.data
+
+    # Now simulate 1 BLE failure
+    fake_device._fail_with_ble_error = True
+    fake_device._fail_times = 1
+
+    data = await coord._async_update_data()
+    # Should not raise, should return stale data
+    assert data is fake_device.data
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_after_too_many_ble_errors():
+    fake_device = FakeDevice()
+    hass = FakeHass()
+    entry = DummyConfigEntry()
+    coord = GoveeH6199DataCoordinator(hass, entry, fake_device)
+
+    # Seed with a successful update
+    await coord._async_update_data()
+
+    fake_device._fail_with_ble_error = True
+    fake_device._fail_times = MAX_SOFT_FAILURES + 1
+
+    # Consume MAX_SOFT_FAILURES-1 failures without error
+    for _ in range(MAX_SOFT_FAILURES - 1):
+        data = await coord._async_update_data()
+        assert data is fake_device.data
+
+    # Next call should raise UpdateFailed
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,198 @@
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakDBusError, BleakError
+from custom_components.hass_govee_h6199.device import GoveeH6199Device
+
+
+class FakeGoveeDevice:
+    """Fake GoveeH6199 for testing the retry logic."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+        self.fail_first: bool = False
+        self.fail_kind: str | None = None
+        self.response: Any = 'ok'
+
+    async def start(self) -> None:
+        # matches real API used in _connect/init, but no-op
+        return None
+
+    async def send_command(self, cmd: Any) -> Any:
+        self.calls.append(cmd)
+        if self.fail_first:
+            self.fail_first = False
+            if self.fail_kind == 'dbus':
+                raise BleakDBusError('org.bluez.Error.Failed', 'ATT 0x0e')
+            if self.fail_kind == 'bleak':
+                raise BleakError('generic bleak error')
+        return self.response
+
+
+class FakeClient:
+    """Fake BleakClient, only what we need for _force_reconnect."""
+
+    def __init__(self, address: str = 'AA:BB:CC:DD:EE:FF') -> None:
+        self.address = address
+        self.disconnected = False
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+
+@pytest.mark.asyncio
+async def test_send_command_retries_on_bleak_dbus_error(monkeypatch: pytest.MonkeyPatch):
+    ble = BLEDevice(address='AA:BB:CC:DD:EE:FF', name='test', details=None)
+    device = GoveeH6199Device('AA:BB:CC:DD:EE:FF', ble)
+
+    fake_govee = FakeGoveeDevice()
+    device._govee_device = fake_govee
+    device._client = FakeClient()
+
+    # Pretend we're already connected & initialized
+    device._connected_event.set()
+    device._init_event.set()
+
+    # Fake reconnect: don't touch real BLE, just keep events set
+    async def fake_force_reconnect():
+        # In real code we'd drop client & reconnect; here it's a no-op
+        device._connected_event.set()
+        device._init_event.set()
+
+    async def fake_retry_command_once(command: Any):
+        # Just call the fake device one more time
+        return await fake_govee.send_command(command)
+
+    # Patch instance methods so _send_command uses our fakes
+    monkeypatch.setattr(device, '_force_reconnect', fake_force_reconnect)
+    monkeypatch.setattr(device, '_retry_command_once', fake_retry_command_once)
+
+    # First call fails with BleakDBusError, second succeeds
+    fake_govee.fail_first = True
+    fake_govee.fail_kind = 'dbus'
+    fake_govee.response = 'ok-after-retry'
+
+    cmd = object()
+    result = await device._send_command(cmd)
+
+    assert result == 'ok-after-retry'
+    # We should have called send_command twice: initial + retry
+    assert len(fake_govee.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_send_command_retries_on_bleak_error(monkeypatch: pytest.MonkeyPatch):
+    ble = BLEDevice(address='AA:BB:CC:DD:EE:FF', name='test', details=None)
+    device = GoveeH6199Device('AA:BB:CC:DD:EE:FF', ble)
+
+    fake_govee = FakeGoveeDevice()
+    device._govee_device = fake_govee
+    device._client = FakeClient()
+
+    device._connected_event.set()
+    device._init_event.set()
+
+    async def fake_force_reconnect():
+        device._connected_event.set()
+        device._init_event.set()
+
+    async def fake_retry_command_once(command: Any):
+        return await fake_govee.send_command(command)
+
+    monkeypatch.setattr(device, '_force_reconnect', fake_force_reconnect)
+    monkeypatch.setattr(device, '_retry_command_once', fake_retry_command_once)
+
+    fake_govee.fail_first = True
+    fake_govee.fail_kind = 'bleak'
+    fake_govee.response = 'ok-after-retry'
+
+    cmd = object()
+    result = await device._send_command(cmd)
+
+    assert result == 'ok-after-retry'
+    assert len(fake_govee.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_reconnect_task_creates_only_one(monkeypatch: pytest.MonkeyPatch):
+    ble = BLEDevice(address='AA:BB:CC:DD:EE:FF', name='test', details=None)
+    dev = GoveeH6199Device('AA:BB:CC:DD:EE:FF', ble)
+
+    async def dummy_connect():
+        await asyncio.sleep(0)  # just yield once
+
+    # Patch method on this instance
+    monkeypatch.setattr(dev, '_connect', dummy_connect)
+
+    dev._ensure_reconnect_task()
+    first = dev._reconnect_task
+
+    # Second call should *not* replace the existing task
+    dev._ensure_reconnect_task()
+    second = dev._reconnect_task
+
+    assert first is second
+    assert first is not None
+
+
+@pytest.mark.asyncio
+async def test_handle_disconnect_stops_ping_and_reconnects(monkeypatch: pytest.MonkeyPatch):
+    ble = BLEDevice(address='AA:BB:CC:DD:EE:FF', name='test', details=None)
+    dev = GoveeH6199Device('AA:BB:CC:DD:EE:FF', ble)
+
+    dev._connected_event.set()
+
+    # fake ping task
+    dev._ping_task = asyncio.create_task(asyncio.sleep(60))
+
+    ensure_reconnect = MagicMock()
+    monkeypatch.setattr(dev, '_ensure_reconnect_task', ensure_reconnect)
+
+    class FakeClient:
+        address = ble.address
+
+    dev._handle_disconnect(FakeClient())
+
+    assert not dev._connected_event.is_set()
+    assert dev._ping_task is None or dev._ping_task.cancelled()
+    ensure_reconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_clears_reconnect_task_on_exit(monkeypatch: pytest.MonkeyPatch):
+    ble = BLEDevice(address='AA:BB:CC:DD:EE:FF', name='test', details=None)
+    dev = GoveeH6199Device('AA:BB:CC:DD:EE:FF', ble)
+
+    # 1) Fake connection so it always "succeeds"
+    async def fake_establish_connection(*args, **kwargs):
+        class FakeClient:
+            def __init__(self, address: str) -> None:
+                self.address = address
+
+        return FakeClient(ble.address)
+
+    import custom_components.hass_govee_h6199.device as device_module  # noqa: PLC0415
+
+    monkeypatch.setattr(device_module, 'establish_connection', fake_establish_connection)
+
+    # 2) Fake Govee device so __init__/start() never blow up
+    fake_govee = FakeGoveeDevice()
+    monkeypatch.setattr(device_module, 'GoveeH6199', MagicMock(return_value=fake_govee))
+
+    # 3) Prevent real ping loop from running forever
+    async def dummy_ping_loop():
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(dev, '_ping_loop', dummy_ping_loop)
+
+    # simulate that _connect is running as reconnect task
+    dev._reconnect_task = asyncio.create_task(dev._connect())
+
+    # Make sure we don't hang forever if something goes wrong
+    await asyncio.wait_for(dev._reconnect_task, timeout=1)
+
+    # After _connect exits, the finally block should have cleared the reference
+    assert dev._reconnect_task is None


### PR DESCRIPTION
1. Add pytest.ini to streamline discovery and filter noisy warnings
2. Introduce conftest shim to import the integration from a hyphenated folder
3. Normalize test imports to custom_components.hass_govee_h6199
4. Add tests:
    - Coordinator: keeps stale data on transient BLE errors; raises after exceeding soft-failure limit
    - Device: retries on Bleak/DBus errors; ensures only one reconnect task; stops ping and schedules reconnect on disconnect; clears reconnect task on successful connect

No functional changes to the integration; testing/tooling only.